### PR TITLE
fix: add permissions

### DIFF
--- a/.github/workflows/auto-assign-label.yaml
+++ b/.github/workflows/auto-assign-label.yaml
@@ -2,25 +2,22 @@ name: Auto Assign and Label
 
 on:
   pull_request:
-    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   assign-reviewers-assignees:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
 
   label-lang:
     runs-on: ubuntu-latest
     continue-on-error: true
-
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
       - uses: actions/labeler@v5
         with:
-          repo-token: ${{ github.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -3,17 +3,22 @@ name: Check Line Linting
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
-  linelint:
+  check-pr-label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
-      # PR 라벨 확인
       - name: Get PR labels
         id: pr-labels
+        continue-on-error: true
         run: |
           pr_number="${{ github.event.pull_request.number }}"
           labels_json=$(gh pr view $pr_number --json labels -q '.labels[].name')
@@ -23,9 +28,15 @@ jobs:
             echo "has_maintenance=false" >> $GITHUB_OUTPUT
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # 줄바꿈 체크
+  check-linelint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
       - name: Check for missing end line breaks
         run: |
           # 따옴표를 제거하고 파일 목록 가져오기


### PR DESCRIPTION
Added necessary permissions to ensure GitHub Actions work correctly after switching to a private repository.

- `pull-requests: write`: Added to allow auto-assignment of reviewers and assignees in PRs.
- `issues: write`: Added as the assignee assignment process may use the `issues` API.
- `contents: read`: Set to allow reading the repository.
- Changed `repo-token` from `github.token` to `secrets.GITHUB_TOKEN` to ensure proper execution in a private repository.

Now, `kentaro-m/auto-assign-action@v2.0.0` and `actions/labeler@v5` should work as expected.

# What does this PR do?
<!-- 
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.
-->

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] 커밋 컨벤션을 확인하셨나요?
- [ ] black formatter를 통한 line inting을 확인 하셨나요?
- **Tag**: Select the appropriate tag for this PR:
  - [ ] `feature`
  - [x] `fix`
  - [ ] `refactor`
  - [ ] `test`
- **Module**: Select the relevant module(s) affected by this PR:
  - [ ] `sql`
  - [ ] `rag`
  - [ ] `base`
  - [x] `deploy`

## How to merge?
- [x] `dev` branch에서 `main` branch로 merge할 경우 **Squash and merge**를 선택해야 합니다.
- [ ] feature branch에서 `dev` branch로 merge할 경우 **Rebase and merge**를 선택해야 합니다.
