### PR TITLE
Fix: prevent script failure when no Python files are changed

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -40,8 +40,13 @@ jobs:
       - name: Check for missing end line breaks
         run: |
           # 따옴표를 제거하고 파일 목록 가져오기
-          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"' | grep '\.py$')
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"' | grep '\.py$' || true)
           success=true
+
+          if [ -z "$files" ]; then
+            echo "변경된 Python 파일이 없습니다."
+            exit 0
+          fi
 
           echo "변경된 Python 파일 목록:"
           echo "$files"


### PR DESCRIPTION
Updated the GitHub Actions workflow to properly handle cases where no Python files are modified.   Now, if there are no changed `.py` files, the script will exit gracefully instead of failing with exit code 1.

# What does this PR do?
<!-- 
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.
-->

Fixes # (issue)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] 커밋 컨벤션을 확인하셨나요?
- [ ] black formatter를 통한 line inting을 확인 하셨나요?
- **Tag**: Select the appropriate tag for this PR:
  - [ ] `feature`
  - [x] `fix`
  - [ ] `refactor`
  - [ ] `test`
- **Module**: Select the relevant module(s) affected by this PR:
  - [ ] `sql`
  - [ ] `rag`
  - [ ] `base`
  - [x] `deploy`

## How to merge?
- [ ] `dev` branch에서 `main` branch로 merge할 경우 **Squash and merge**를 선택해야 합니다.
- [ ] feature branch에서 `dev` branch로 merge할 경우 **Rebase and merge**를 선택해야 합니다.
