### PR TITLE
Fix: Remove label-lang due to permission issue in forked repository

### DIFF
--- a/.github/workflows/auto-assign-label.yaml
+++ b/.github/workflows/auto-assign-label.yaml
@@ -13,11 +13,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
-
-  label-lang:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/labeler@v5
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since this PR was created from a forked repository, GitHub Actions cannot apply labels due to permission restrictions. To resolve this issue, the `label-lang` configuration is being removed.

# What does this PR do?
<!-- 
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.
-->

Fixes # (issue)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] 커밋 컨벤션을 확인하셨나요?
- [ ] black formatter를 통한 line inting을 확인 하셨나요?
- **Tag**: Select the appropriate tag for this PR:
  - [ ] `feature`
  - [x] `fix`
  - [ ] `refactor`
  - [ ] `test`
- **Module**: Select the relevant module(s) affected by this PR:
  - [ ] `sql`
  - [ ] `rag`
  - [ ] `base`
  - [ ] `deploy`

## How to merge?
- [ ] `dev` branch에서 `main` branch로 merge할 경우 **Squash and merge**를 선택해야 합니다.
- [ ] feature branch에서 `dev` branch로 merge할 경우 **Rebase and merge**를 선택해야 합니다.
